### PR TITLE
Update value in constants.ts

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,7 @@ export const traineeOptions: Option<number>[] = [
 	{ name: 'Almond Eye (The Changer)', value: 112901, status: 'upcoming' },
 	{ name: 'Aston Machan (Everlasting Sweet Treat)', value: 108702, status: 'upcoming' },
 	{ name: 'Aston Machan (Flare)', value: 108701, status: 'upcoming' },
-	{ name: 'Bamboo Memory (Ambition of the Black Iron)', value: 105301, status: 'upcoming' },
+	{ name: 'Bamboo Memory (Iron Ambition)', value: 105301, status: 'released' },
 	{ name: 'Bamboo Memory (Ultra☆Marine)', value: 105302, status: 'upcoming' },
 	{ name: 'Believe (Essence)', value: 109501, status: 'upcoming' },
 	{ name: 'Biko Pegasus (Gale Pegasus Type Zero)', value: 105401, status: 'upcoming' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the name of the Bamboo Memory option from “Ambition of the Black Iron” to “Iron Ambition.”
  * Marked that option as released, so it now appears as an available item instead of an upcoming one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->